### PR TITLE
Bump Java and dependency versions

### DIFF
--- a/blcmodapibukkit/pom.xml
+++ b/blcmodapibukkit/pom.xml
@@ -35,8 +35,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/blcmodapibukkit/pom.xml
+++ b/blcmodapibukkit/pom.xml
@@ -34,6 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>

--- a/blcmodapibukkit/pom.xml
+++ b/blcmodapibukkit/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.6.2</version>
+            <version>2.8.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/blcmodapibukkit/pom.xml
+++ b/blcmodapibukkit/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/blcmodapibungee/pom.xml
+++ b/blcmodapibungee/pom.xml
@@ -34,6 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>


### PR DESCRIPTION
I'm currently working on adding [Velocity](https://www.velocitypowered.com/) support to this project. (I'll create another pull request for it, though.)

However, the build fails because the source and target versions of the Bukkit module are set to Java 6:
```
[ERROR] goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project blccpsapibukkit could not be executed:  Compilation error: Compilation error:  
ERROR] Source option 6 is no longer supported.  Use 7 or higher. 
ERROR] Target option 6 is no longer supported.  Use 7 or higher.
```

Updating the module to Java 7 fixed the issue. I took this opportunity to update the Maven Shade Plugin and Gson version as well. I tested both the Bukkit and the BungeeCord on my instances and everything still works.