### PR TITLE
Support for Velocity proxy

### DIFF
--- a/blcmodapivelocity/pom.xml
+++ b/blcmodapivelocity/pom.xml
@@ -24,6 +24,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>

--- a/blcmodapivelocity/pom.xml
+++ b/blcmodapivelocity/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>badlionclientmodapi</artifactId>
+        <groupId>net.badlion</groupId>
+        <version>1.2.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blcmodapivelocity</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <defaultGoal>clean install</defaultGoal>
+        <finalName>badlionclientmodapivelocity</finalName>
+        <sourceDirectory>src/main/java</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>1.0.3-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>velocity-repo</id>
+            <url>https://repo.velocitypowered.com/snapshots/</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/blcmodapivelocity/pom.xml
+++ b/blcmodapivelocity/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>1.0.3-SNAPSHOT</version>
+            <version>1.0.4-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
@@ -8,8 +8,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Path;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -48,7 +48,7 @@ public class BlcModApiVelocity {
         
         if (!dataFolder.exists()) {
             if (!dataFolder.mkdir()) {
-                this.logger.log(Level.SEVERE, "Failed to create plugin directory.");
+                this.logger.error("Failed to create plugin directory.");
             }
         }
         
@@ -60,9 +60,9 @@ public class BlcModApiVelocity {
             // Only register the listener if the config loads successfully
             this.proxy.getEventManager().register(this, new PlayerListener(this));
 
-            this.logger.log(Level.INFO, "Successfully setup BadlionClientModAPI plugin.");
+            this.logger.info("Successfully setup BadlionClientModAPI plugin.");
         } catch (Exception e) {
-            this.logger.log(Level.SEVERE, "Error with config for BadlionClientModAPI plugin.");
+            this.logger.error("Error with config for BadlionClientModAPI plugin.");
             e.printStackTrace();
         }
     }
@@ -71,7 +71,7 @@ public class BlcModApiVelocity {
 		try (Reader reader = new BufferedReader(new FileReader(file))) {
 			return BlcModApiVelocity.GSON_NON_PRETTY.fromJson(reader, Conf.class);
 		} catch (FileNotFoundException ex) {
-			this.logger.log(Level.INFO,"No Config Found: Saving default...");
+			this.logger.info("No Config Found: Saving default...");
 			Conf conf = new Conf();
 			this.saveConf(conf, new File(this.dataFolderPath.toFile(), "config.json"));
 			return conf;

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
@@ -11,10 +11,10 @@ import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.eventbus.Subscribe;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
@@ -26,10 +26,10 @@ import net.badlion.blcmodapivelocity.listener.PlayerListener;
 @Plugin(id = "blcmodapivelocity", name = "BadlionClientModAPI", version = "1.0", authors = {"Badlion"})
 public class BlcModApiVelocity {
 
-	public static final Gson GSON_NON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
-	public static final Gson GSON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().setPrettyPrinting().create();
+    public static final Gson GSON_NON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
+    public static final Gson GSON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().setPrettyPrinting().create();
 
-	private final ProxyServer proxy;
+    private final ProxyServer proxy;
     private final Logger logger;
     private final Path dataFolderPath;
     private Conf conf;
@@ -67,30 +67,30 @@ public class BlcModApiVelocity {
         }
     }
 
-	public Conf loadConf(File file) throws IOException {
-		try (Reader reader = new BufferedReader(new FileReader(file))) {
-			return BlcModApiVelocity.GSON_NON_PRETTY.fromJson(reader, Conf.class);
-		} catch (FileNotFoundException ex) {
-			this.logger.info("No Config Found: Saving default...");
-			Conf conf = new Conf();
-			this.saveConf(conf, new File(this.dataFolderPath.toFile(), "config.json"));
-			return conf;
-		}
-	}
+    public Conf loadConf(File file) throws IOException {
+        try (Reader reader = new BufferedReader(new FileReader(file))) {
+            return BlcModApiVelocity.GSON_NON_PRETTY.fromJson(reader, Conf.class);
+        } catch (FileNotFoundException ex) {
+            this.logger.info("No Config Found: Saving default...");
+            Conf conf = new Conf();
+            this.saveConf(conf, new File(this.dataFolderPath.toFile(), "config.json"));
+            return conf;
+        }
+    }
 
-	private void saveConf(Conf conf, File file) {
-		try (FileWriter writer = new FileWriter(file)) {
-			BlcModApiVelocity.GSON_PRETTY.toJson(conf, writer);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-	}
+    private void saveConf(Conf conf, File file) {
+        try (FileWriter writer = new FileWriter(file)) {
+            BlcModApiVelocity.GSON_PRETTY.toJson(conf, writer);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
 
-	public Conf getConf() {
-		return this.conf;
-	}
+    public Conf getConf() {
+        return this.conf;
+    }
 
-	public MinecraftChannelIdentifier getBlcModsChannel() {
+    public MinecraftChannelIdentifier getBlcModsChannel() {
         return this.blcModsChannel;
     }
 }

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/BlcModApiVelocity.java
@@ -1,0 +1,96 @@
+package net.badlion.blcmodapivelocity;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+
+import net.badlion.blcmodapivelocity.listener.PlayerListener;
+
+@Plugin(id = "blcmodapivelocity", name = "BadlionClientModAPI", version = "1.0", authors = {"Badlion"})
+public class BlcModApiVelocity {
+
+	public static final Gson GSON_NON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
+	public static final Gson GSON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().setPrettyPrinting().create();
+
+	private final ProxyServer proxy;
+    private final Logger logger;
+    private final Path dataFolderPath;
+    private Conf conf;
+    private MinecraftChannelIdentifier blcModsChannel;
+
+    @Inject
+    public BlcModApiVelocity(ProxyServer proxy, Logger logger, @DataDirectory Path dataFolderPath) {
+        this.proxy = proxy;
+        this.logger = logger;
+        this.dataFolderPath = dataFolderPath;
+    }
+
+    @Subscribe
+    public void onProxyInitialize(ProxyInitializeEvent event) {
+        final File dataFolder = this.dataFolderPath.toFile();
+        
+        if (!dataFolder.exists()) {
+            if (!dataFolder.mkdir()) {
+                this.logger.log(Level.SEVERE, "Failed to create plugin directory.");
+            }
+        }
+        
+        try {
+            this.conf = loadConf(new File(dataFolder, "config.json"));
+
+            this.blcModsChannel = MinecraftChannelIdentifier.create("badlion", "mods");
+
+            // Only register the listener if the config loads successfully
+            this.proxy.getEventManager().register(this, new PlayerListener(this));
+
+            this.logger.log(Level.INFO, "Successfully setup BadlionClientModAPI plugin.");
+        } catch (Exception e) {
+            this.logger.log(Level.SEVERE, "Error with config for BadlionClientModAPI plugin.");
+            e.printStackTrace();
+        }
+    }
+
+	public Conf loadConf(File file) throws IOException {
+		try (Reader reader = new BufferedReader(new FileReader(file))) {
+			return BlcModApiVelocity.GSON_NON_PRETTY.fromJson(reader, Conf.class);
+		} catch (FileNotFoundException ex) {
+			this.logger.log(Level.INFO,"No Config Found: Saving default...");
+			Conf conf = new Conf();
+			this.saveConf(conf, new File(this.dataFolderPath.toFile(), "config.json"));
+			return conf;
+		}
+	}
+
+	private void saveConf(Conf conf, File file) {
+		try (FileWriter writer = new FileWriter(file)) {
+			BlcModApiVelocity.GSON_PRETTY.toJson(conf, writer);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+	}
+
+	public Conf getConf() {
+		return this.conf;
+	}
+
+	public MinecraftChannelIdentifier getBlcModsChannel() {
+        return this.blcModsChannel;
+    }
+}

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/Conf.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/Conf.java
@@ -1,0 +1,24 @@
+package net.badlion.blcmodapivelocity;
+
+import com.google.gson.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Conf {
+
+	private Map<String, DisallowedMods> modsDisallowed =  new HashMap<>();
+
+
+	public Map<String, DisallowedMods> getModsDisallowed() {
+		return this.modsDisallowed;
+	}
+
+	private class DisallowedMods {
+
+		private boolean disabled;
+		private JsonObject extra_data;
+
+	}
+
+}

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/Conf.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/Conf.java
@@ -7,18 +7,18 @@ import java.util.Map;
 
 public class Conf {
 
-	private Map<String, DisallowedMods> modsDisallowed =  new HashMap<>();
+    private Map<String, DisallowedMods> modsDisallowed =  new HashMap<>();
 
 
-	public Map<String, DisallowedMods> getModsDisallowed() {
-		return this.modsDisallowed;
-	}
+    public Map<String, DisallowedMods> getModsDisallowed() {
+        return this.modsDisallowed;
+    }
 
-	private class DisallowedMods {
+    private class DisallowedMods {
 
-		private boolean disabled;
-		private JsonObject extra_data;
+        private boolean disabled;
+        private JsonObject extra_data;
 
-	}
+    }
 
 }

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/listener/PlayerListener.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/listener/PlayerListener.java
@@ -1,0 +1,24 @@
+package net.badlion.blcmodapivelocity.listener;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PostLoginEvent;
+import com.velocitypowered.api.proxy.Player;
+
+import net.badlion.blcmodapivelocity.BlcModApiVelocity;
+
+public class PlayerListener {
+
+	private BlcModApiVelocity plugin;
+
+	public PlayerListener(BlcModApiVelocity plugin) {
+		this.plugin = plugin;
+	}
+
+
+	@Subscribe
+	public void onLogin(PostLoginEvent event) {
+		// Send the disallowed mods to players when they login to the proxy. A notification will appear on the Badlion Client so they know the mod was disabled
+		Player player = event.getPlayer();
+		player.sendPluginMessage(this.plugin.getBlcModsChannel(), BlcModApiVelocity.GSON_NON_PRETTY.toJson(this.plugin.getConf().getModsDisallowed()).getBytes());
+	}
+}

--- a/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/listener/PlayerListener.java
+++ b/blcmodapivelocity/src/main/java/net/badlion/blcmodapivelocity/listener/PlayerListener.java
@@ -8,17 +8,17 @@ import net.badlion.blcmodapivelocity.BlcModApiVelocity;
 
 public class PlayerListener {
 
-	private BlcModApiVelocity plugin;
+    private BlcModApiVelocity plugin;
 
-	public PlayerListener(BlcModApiVelocity plugin) {
-		this.plugin = plugin;
-	}
+    public PlayerListener(BlcModApiVelocity plugin) {
+        this.plugin = plugin;
+    }
 
 
-	@Subscribe
-	public void onLogin(PostLoginEvent event) {
-		// Send the disallowed mods to players when they login to the proxy. A notification will appear on the Badlion Client so they know the mod was disabled
-		Player player = event.getPlayer();
-		player.sendPluginMessage(this.plugin.getBlcModsChannel(), BlcModApiVelocity.GSON_NON_PRETTY.toJson(this.plugin.getConf().getModsDisallowed()).getBytes());
-	}
+    @Subscribe
+    public void onLogin(PostLoginEvent event) {
+        // Send the disallowed mods to players when they login to the proxy. A notification will appear on the Badlion Client so they know the mod was disabled
+        Player player = event.getPlayer();
+        player.sendPluginMessage(this.plugin.getBlcModsChannel(), BlcModApiVelocity.GSON_NON_PRETTY.toJson(this.plugin.getConf().getModsDisallowed()).getBytes());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <packaging>pom</packaging>
     <version>1.2.0</version>
     <modules>
+        <module>blcmodapivelocity</module>
         <module>blcmodapibungee</module>
         <module>blcmodapibukkit</module>
     </modules>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Badlion Client Mod API
 
-This repository explains how to disable Badlion Client mods and mod features via Bungee/Bukkit plugin.
+This repository explains how to disable Badlion Client mods and mod features via Velocity/Bungee/Bukkit plugin.
 
 By default all mods on the Badlion Client are not restricted and a user can enable any of the mods at anytime. By using this plugin you remove the ability for a user to activate certain mods or features of mods while they are playing on your server. The user will gain control over the ability to use these mods/features again when they leave your server.
 
@@ -12,7 +12,7 @@ How to install the Badlion Client Mod API on your server.
 
 #### Quick Installation (for non-programmers)
 
-1. Download **either** the latest bukkit or bungee plugin from our releases (you don't need both, we recommend using the BungeeCord plugin if you are running BungeeCord): https://github.com/BadlionNetwork/BadlionClientModAPI/releases
+1. Download **either** the latest bukkit, bungee or velocity plugin from our releases (you don't need both, we recommend using the BungeeCord or Velocity plugin if you are running BungeeCord or Velocity): https://github.com/BadlionNetwork/BadlionClientModAPI/releases
 2. Place the downloaded plugin into your `plugins` directory on your server.
 3. Turn on the BungeeCord or Bukkit server and a default config will be automatically made in `plugins/BadlionClientModAPI/config.json`
 4. Edit the config as you see fit and reboot the server after you have finished editing the config (see below for more information).


### PR DESCRIPTION
This pull request adds support for [Velocity](https://www.velocitypowered.com/), a Minecraft server proxy with unparalleled server support, scalability, and flexibility. It's an alternative to BungeeCord, which is becoming increasingly popular. The Velocity API is somewhat similar to to that of BungeeCord, so porting was quite easy and maintaining it takes very little time. I tested this addition on my Velocity instance and everything works as expected.